### PR TITLE
Fix for issue #8 Error occurs when accessing userEmail from message pop-up window

### DIFF
--- a/chrome/content-script.js
+++ b/chrome/content-script.js
@@ -78,11 +78,12 @@ function getGmailObject() {
     // console.log(app.data);
     });
 
+    /*
     var actualCode_ORIGINAL = ['setTimeout(function() {', 
         'document.dispatchEvent(new CustomEvent("GTT_connectExtension", { ',
         '    detail: GLOBALS',
         '}));}, 0);'].join('\n');
-
+    */
     
     var actualCode = `
         function timeOutFxn() {


### PR DESCRIPTION
Steps to repro:
1) Pick an individual message in GMail
2) Click the "Open in New Window" arrow icon in the upper right corner of the GMail message
3) Click the "Add Card" in the new pop-up window
4) Assign to your trello board, etc., as usual
5) Click green "Add to Trello Card"
Result: Hangs on "Waiting for Trello..."
Expected: Card added to Trello.

Code issue: GMail GLOBALS not available in pop-up window message. Borrowing code from GMail.js project, if GLOBALS is undefined, try looking for it in parent window.
Additional cleanup: Instead of passing GLOBALS reference around, will only pass back what is needed, the userEmail.