### PR TITLE
Add markdown to description via specific tags

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "GMail to Trello",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "manifest_version": 2,
   "description": "A free tool for GMail and Trello integration, allow creating new card from email thread and easily searching back",
   "icons": {

--- a/chrome/views/gmailView.js
+++ b/chrome/views/gmailView.js
@@ -190,8 +190,8 @@ GmailToTrello.GmailView.prototype.markdownify = function($emailBody) {
      $(':header', $html).each(function(index, value) {
         var text = $(this).text();
         var nodeName = $(this).prop("nodeName") || "";
-        var re = new RegExp(text, "gi");
         var x = '0' + nodeName.substr(-1);
+        var re = new RegExp(text, "gi");
         var replaced = body.replace(re, "\n" + ('#'.repeat(x)) + " " + text + "\n");
         body = replaced;
     });

--- a/chrome/views/popupView.js
+++ b/chrome/views/popupView.js
@@ -292,7 +292,7 @@ GmailToTrello.PopupView.prototype.bindData = function(data) {
             <li>Check "Clear data from hosted apps"</li>
 			<li>Press button "Clear browsing data"</li>
 			</ol>
-			<button class="hideMsg" title="Dismiss message">Done</input>`
+			<button class="hideMsg" title="Dismiss message">Done</button>`
             );
     });
 
@@ -616,7 +616,7 @@ GmailToTrello.PopupView.prototype.displaySubmitCompleteForm = function() {
             .attr('href', data.url)
             .attr('target', '_blank')
             .append(data.title))
-        + '<p><input type="button" class="hideMsg" value="Done" title="Dismiss message"></input></p>'
+        + '<br /><br /><button class="hideMsg" title="Dismiss message">Done</button>'
     );
 
     this.$popupContent.hide();


### PR DESCRIPTION
 - Work in progress to use innerHTML to convert email text to markdown instead of just plaintext.
 - Fix bug: </input> -> </button>, additional markdown now supported in emailbody convert.

Decided instead of working to minify from innerHTML, will take innerText and add markdown to specific elements for biggest "bang for the buck." headers, anchor/links/href, a few others supported. Images support is in but turned off, seemed to make description TOO busy.