### PR TITLE
top/bottom popup -> arrow icons; attachments default unchecked; save/restore popup width

### DIFF
--- a/chrome/CHANGES.md
+++ b/chrome/CHANGES.md
@@ -4,6 +4,12 @@ A free tool that provides an extra 'Add card' button on Gmail UI to add current 
 
 CHANGE LOG:
 
+Version 2.4.9
+---------------
+- Change top/bottom popup to up-line and down-line arrow icons
+- Change default for attachments to unchecked
+- Fix bug where popup width wasn't being saved and restored correctly
+
 Version 2.4.8
 ---------------
 - Have reproducable case for settings not being saved; fixed with using chrome sync settings and getting timing right

--- a/chrome/app.js
+++ b/chrome/app.js
@@ -419,7 +419,7 @@ GmailToTrello.App.prototype.loadSettings = function(popup) {
     const setID = this.CHROME_SETTINGS_ID;
     chrome.storage.sync.get(setID, function(response) {
         if (response && response.hasOwnProperty(setID)) {
-            $.extend(self.popupView.data.settings, JSON.parse(response[setID])); // NOTE (Ace, 7-Feb-2017): Might need to store these off the app object
+            self.popupView.data.settings = JSON.parse(response[setID]); // NOTE (Ace, 7-Feb-2017): Might need to store these off the app object
         }
         if (popup) { 
             popup.init_popup(); 
@@ -444,3 +444,16 @@ GmailToTrello.App.prototype.saveSettings = function() {
     chrome.storage.sync.set(hash);  // NOTE (Ace, 7-Feb-2017): Might need to store these off the app object
 };
 
+/**
+ * Encode entities
+ */
+GmailToTrello.App.prototype.encodeEntities = function(s) {
+    return $("<div/>").text(s).html();
+};
+
+/**
+ * Decode entities
+ */
+GmailToTrello.App.prototype.decodeEntities = function(s) {
+    return $("<div/>").html(s).text();
+};

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GMail to Trello",
   "short_name": "GtT",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "manifest_version": 2,
   "description": "GMail to Trello integration. Create new Trello cards from Google mail threads with backlinks.",
   "icons": {

--- a/chrome/style.css
+++ b/chrome/style.css
@@ -105,8 +105,8 @@ ul#gttLabels {float:left; margin:0; padding:0;}
 #gttPopup .hdr {font-weight: bold; vertical-align: middle; line-height: 30px; height: 30px; background:#ECEAED; border-bottom: 1px solid #ccc;}
 #gttPopup .hdr a {text-decoration: none;}
 #gttPopup .hdr a:hover {text-decoration: underline;}
-#gttPopup .hdr .item {float:left; margin-right: 10px}
-#gttPopup .member-avatar {float:left; width:30px; height: 30px; border-radius: 3px; background: lightgray; color: black; text-align: center;}
+#gttPopup .hdr .item {float: left; margin-right: 10px}
+#gttPopup .member-avatar {float: left; width:30px; height: 30px; border-radius: 3px; background: lightgray; color: black; text-align: center;}
 #gttPopup .member-avatar:hover {color:lightblue; background:darkgray;}
 #gttPopup #close-button, #gttPopup .popupMsg .hideMsg {float: right; margin: 0; padding: 0 10px; border-radius: 3px; color: black; background: lightgray; font-weight: bold; font-size:200%; text-decoration: none;}
 #gttPopup #close-button:hover, #gttPopup .popupMsg .hideMsg:hover {color:red; background:darkgray;}
@@ -115,4 +115,6 @@ ul#gttLabels {float:left; margin:0; padding:0;}
 #gttPopup #gttAttachments {height: 50px; width: 100%; display: inline-block; overflow: auto; padding: 0; margin: 0;}
 #gttPopup #gttAttachments input[type=checkbox] {width: 15px;}
 #gttPopup #gttAttachments label {display: inline-block; padding-left: 24px; text-indent: -18px;}
+
+#gttPopup #gttPosition {-webkit-transform: rotate(90deg); display: inline-block; padding-top: 2px; font-weight: bold; font-size: 200%; vertical-align: middle;}
 

--- a/chrome/views/popupView.html
+++ b/chrome/views/popupView.html
@@ -50,10 +50,12 @@
                 <dt>Attach:</dt>
                 <dd id="gttAttachments" />
                 <dd><input type="button" disabled="true" id="addTrelloCard" value="Add Trello card" />
-                    at <select id="gttPosition" style="margin-left:2px;">
-                            <option value="bottom">bottom</option>
-                            <option value="top">top</option>
+                <!-- <select id="gttPosition" style="margin-left:2px; display:inline-block;">
+                            <option value="bottom" title="Add at bottom" style="-webkit-transform: rotate(90deg)";>&rarrb;</option>
+                            <option value="top" title="Add at top" style="-webkit-transform: rotate(90deg);"">&larrb;</option>
                         </select>
+                        -->
+                        <a id="gttPosition" value="bottom" title="Add at bottom">&rarrb;</a>
                 </dd>
            </dl>
        </div>


### PR DESCRIPTION
- Change top/bottom popup to up-line and down-line arrow icons
- Change default for attachments to unchecked
- Fix bug where popup width wasn't being saved and restored correctly