### PR TITLE
pInterest loads with white fixed: jquery ui css load point changed, reduced matches[] in manifest

### DIFF
--- a/chrome/CHANGES.md
+++ b/chrome/CHANGES.md
@@ -4,6 +4,12 @@ A free tool that provides an extra 'Add card' button on Gmail UI to add current 
 
 CHANGE LOG:
 
+Version 2.5.0.4
+-------------------
+- Fix pInterest loads with white overlay on top of first 20 pinned items -- was conflicting with jQuery UI CSS
+- Moved jQuery-ui-css loading to top of popup
+- Changed matches to mail.google.com instead of all urls.
+
 Version 2.5.0.3
 -------------------
 - Fix problem of email with no body

--- a/chrome/content-script.js
+++ b/chrome/content-script.js
@@ -34,7 +34,7 @@ function log(data) {
  * @param  sender       
  * @param  sendResponse Callback function
  */
-function requestHandler(request, sender, sendResponse) {
+ function requestHandler(request, sender, sendResponse) {
     switch (request.message) {
         case "initialize":
             log('GTT::GlobalInit: '+globalInit.toString());
@@ -49,7 +49,6 @@ function requestHandler(request, sender, sendResponse) {
                 });
             }, 1000);
             
-            /**/
             break;
     }
 }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GMail to Trello",
   "short_name": "GtT",
-  "version": "2.5.0.3",
+  "version": "2.5.0.4",
   "manifest_version": 2,
   "description": "GMail to Trello integration. Create new Trello cards from Google mail threads with backlinks.",
   "icons": {
@@ -10,13 +10,13 @@
   },
   "page_action": {
     "default_icon": "images/icon-16.png",
-    "default_title": "GMail-to-Trello: GMail detected"
+    "default_title": "GMail-to-Trello"
   },
 
   "background": {"scripts": ["background.js"]},
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://mail.google.com/*"],
       "js": [
           "lib/jquery-3.1.1.min.js",
           "lib/jquery-ui-1.12.1.min.js",
@@ -33,8 +33,7 @@
           "content-script.js"
       ],
       "css": [
-        "style.css",
-        "lib/jquery-ui-1.12.1.min.css"
+        "style.css"
       ]
     }
   ],
@@ -46,7 +45,7 @@
     "images/doc-question-mark-512.png",
     "views/popupView.html",
     "lib/jquery-3.1.1.min.map",
-    "lib/jquery-3.1.1.min.js",
+    "lib/jquery-ui-1.12.1.min.css",
     "inject.js"
   ],
   "homepage_url": "https://trello.com/b/CGU9BYgd/gmail-to-trello-development",

--- a/chrome/style.css
+++ b/chrome/style.css
@@ -2,7 +2,8 @@
 
 .clearfix:after {
     content: "";
-    display: table; /* Seems to do better than "block" */
+    /* Seems to do better than "block": */
+    display: table; 
     clear: both;
 }
 

--- a/chrome/views/popupView.html
+++ b/chrome/views/popupView.html
@@ -1,14 +1,15 @@
- <div id="gttPopup" class="J-M jQjAxd open" style="display:none">
+<link rel="stylesheet" href="%jquery-ui-css%">
+<div id="gttPopup" class="J-M jQjAxd open" style="display:none">
     <div id="gttPopupSlider"></div>
     <div class="inner">
-  <div class="hdr clearfix item">
-    <a id="gttAvatarURL" target="_blank" title="Open your Trello homepage" class="member-avatar"><span id="gttAvatarText" /><img id="gttAvatarImg" src='' /></a>
-    <a id="gttUsername" target="_blank" title="Open your Trello homepage" style="margin-left:5px;">Username</a>
-    | <a id="gttSignOutButton" title="Sign out">Sign out</a>
-    | <a href="https://trello.com/b/CGU9BYgd/gmail-to-trello-development" target="_blank" title="Open Gmail-to-Trello Feature/Bug board in a new window">Features/Bugs</a>
-    <a id="close-button" title="Close">&times;</a>
-  </div>
-  <div class="popupMsg">Loading...</div>
+	<div class="hdr clearfix item">
+	    <a id="gttAvatarURL" target="_blank" title="Open your Trello homepage" class="member-avatar"><span id="gttAvatarText" /><img id="gttAvatarImg" src='' /></a>
+	    <a id="gttUsername" target="_blank" title="Open your Trello homepage" style="margin-left:5px;">Username</a>
+	    | <a id="gttSignOutButton" title="Sign out">Sign out</a>
+	    | <a href="https://trello.com/b/CGU9BYgd/gmail-to-trello-development" target="_blank" title="Open Gmail-to-Trello Feature/Bug board in a new window">Features/Bugs</a>
+	    <a id="close-button" title="Close">&times;</a>
+   </div>
+   <div class="popupMsg">Loading...</div>
         <div class="content menuInnerContainer" style="display:none">
             <dl>
                 <dt style="display:none">Orgs. filter:</dt>

--- a/chrome/views/popupView.js
+++ b/chrome/views/popupView.js
@@ -72,6 +72,7 @@ GmailToTrello.PopupView.prototype.init = function() {
         this.parent.loadSettings(this);
     } else {
         $.get(chrome.extension.getURL('views/popupView.html'), function(data){
+            data = self.parent.replacer(data, {'jquery-ui-css': chrome.extension.getURL('lib/jquery-ui-1.12.1.min.css')});
             self.html['popup'] = data;
             self.$toolBar.append(data);
             self.parent.loadSettings(self);


### PR DESCRIPTION
- Fix pInterest loads with white overlay on top of first 20 pinned items -- was conflicting with jQuery UI CSS
- Moved jQuery-ui-css loading to top of popup
- Changed chrome extension matches[] from "all urls" to only mail.google.com.