### PR TITLE
Member assignment persist; Labels/Members shift-click to clear; GMail -> Gmail

### DIFF
--- a/chrome/CHANGES.md
+++ b/chrome/CHANGES.md
@@ -4,10 +4,15 @@ A free tool that provides an extra 'Add card' button on Gmail UI to add current 
 
 CHANGE LOG:
 
+Verison 2.5.1.2
+------------------
+- Fix member assignment buttons to persist across board changes
+- Shift-click "Labels:" or "Members:" to clear
+- Fix typos GMail -> Gmail
+
 Verison 2.5.1.1
 ------------------
 - Layout changes to accomodate smaller screens
-
 
 Version 2.5.1.0
 ------------------

--- a/chrome/app.js
+++ b/chrome/app.js
@@ -578,3 +578,43 @@ GmailToTrello.App.prototype.decodeEntities = function(s) {
     return ta.value;
     // jQuery way, less safe: return $("<textarea />").html(s).text();
 };
+
+/**
+ * Check for ctrl/alt/shift down:
+ */
+GmailToTrello.App.prototype.modKey = function(event) {
+    var retn = '';
+
+    if (event.ctrlKey) {
+        retn = 'ctrl-';
+        if (event.ctrlLeft) {
+            retn = 'left';
+        }
+    } else if (event.altKey) {
+        retn = 'alt-';
+        if (event.altLeft) {
+            retn = 'left';
+        }
+    } else if (event.shiftKey) {
+        retn = 'shift-';
+        if (event.shiftLeft) {
+            retn += 'left';
+        }
+    } else if (event.metaKey) {
+        retn = 'metakey-';
+        if (window.navigator.platform.indexOf('Mac') !== -1) {
+            retn += 'clover';
+        } else {
+            retn += 'windows';
+        }
+    }
+
+    // If the string is partial, then it was the right-side key:
+    if (retn.slice(-1) === '-') {
+        retn += 'right';
+    }
+
+    return retn;
+};
+
+// End, app.js

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -1,5 +1,5 @@
 /**
- * Detect GMail's URL everytimes a tab is reloaded or openned
+ * Detect Gmail's URL everytimes a tab is reloaded or openned
  */
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     log(changeInfo.status);

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,16 +1,17 @@
 {
-  "name": "GMail to Trello",
+  "name": "Gmail-to-Trello",
   "short_name": "GtT",
-  "version": "2.5.1.1",
+  "version": "2.5.1.2",
   "manifest_version": 2,
-  "description": "GMail to Trello integration. Create new Trello cards from Google mail threads with backlinks.",
+  "description": "Gmail to Trello integration. Create new Trello cards from Google mail threads with backlinks.",
   "icons": {
     "16": "images/icon-16.png",
     "48": "images/icon-48.png"
   },
   "page_action": {
     "default_icon": "images/icon-16.png",
-    "default_title": "GMail-to-Trello"
+    "default_title": "Gmail-to-Trello",
+    "default_popup": "options.html"
   },
 
   "background": {"scripts": ["background.js"]},

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -1,13 +1,13 @@
 <html>
-<head><title>Gmail To Trello Extension Options</title></head>
+<head><title>GMail-to-Trello Extension Options</title></head>
 <body>
-<h3>Gmail To Trello Extension Options</h3>
-<ul>
-<li> <input type="checkbox" id="debugmode" /> <label for="debugmode">Enable debug mode</label></li>
-<li><label for="dateformat">Date format:</label>
+<h4>GMail-to-Trello Extension Options</h4>
+<input type="checkbox" id="debugmode" /> <label for="debugmode">Enable debug mode</label>
+<p />
+<label for="dateformat">Date format:</label>
 	<input type="text" id="dateformat" value="MMM d, yyyy" />
-	<button id="default" title="Restore date to default format">Default</button> </li>
-</ul>
+	<button id="default" title="Restore date to default format">Default</button>
+<p />
 <button id="save">Save</button> <span id="status" style="color: red">&nbsp;</span>
 </body>
 <script src="options.js"></script>

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -9,7 +9,7 @@ function save_options() {
     status.innerHTML = "Options Saved.";
     setTimeout(function() {
       status.innerHTML = "&nbsp;";
-    }, 1500);
+    }, 2500);
   });
 }
 

--- a/chrome/views/popupView.html
+++ b/chrome/views/popupView.html
@@ -4,13 +4,13 @@
     <div class="inner">
         <div class="hdr clearfix item">
             <a id="gttAvatarURL" target="_blank" title="Open your Trello homepage" class="member-avatar"><span id="gttAvatarText" /><img id="gttAvatarImg" width='30' height='30' src='' /></a>
-            <a id="gttUsername" target="_blank" title="Open your Trello homepage" style="margin-left:5px;">Username</a>
+            <a id="gttUsername" target="_blank" title="Open your Trello homepage" style="margin-left: 5px;">Username</a>
             | <a id="gttSignOutButton" title="Sign out">Sign out</a>
             | <a href="https://trello.com/b/CGU9BYgd/gmail-to-trello-development" target="_blank" title="Open Gmail-to-Trello Feature/Bug board in a new window">Features/Bugs</a>
             <a id="close-button" title="Close">&times;</a>
         </div>
         <div class="popupMsg">Loading...</div>
-        <div class="content menuInnerContainer" style="display:none">
+        <div class="content menuInnerContainer" style="display: none;">
             <div class="gttTopRight">
                 <a id="gttPosition" value="bottom" title="Add to bottom">&rarrb;</a>
                 <input type="button" disabled="true" id="addToTrello" value="Add to Trello" />
@@ -24,12 +24,12 @@
                         <option value="">...please pick a board...</option>
                     </select>
                 </dd>
-                <dt>Labels:</dt>
+                <dt id="gttLabelsHeader" title="Shift-click me to clear all labels">Labels:</dt>
                 <dd class="clearfix listrow">
                     <div id="gttLabelsMsg">...please pick a board...</div>
                     <ul id="gttLabels" />
                 </dd>
-                <dt>Assign:</dt>
+                <dt id="gttMembersHeader" title="Shift-click me to clear all assignments">Assign:</dt>
                 <dd class="clearfix listrow">
                     <div id="gttMembersMsg">...please pick a board...</div>
                     <ul id="gttMembers" />
@@ -37,15 +37,15 @@
                 <dt>Due:</dt>
                 <dd>
                     <input type="date" id="gttDue_Date" /> <input type="time" id="gttDue_Time" />
-                    <input type="checkbox" checked="checked" id="chkMarkdown" style="margin-left:10px" />
+                    <input type="checkbox" checked="checked" id="chkMarkdown" style="margin-left: 10px;" />
                     <label for="chkMarkdown">Markdown</label>
-                    <input type="checkbox" checked="checked" id="chkBackLink" style="margin-left:10px" />
-                    <label for="chkBackLink">Add GMail link</label>
+                    <input type="checkbox" checked="checked" id="chkBackLink" style="margin-left: 10px;" />
+                    <label for="chkBackLink">Add Gmail link</label>
                 </dd>
                 <dt>Title:</dt>
                 <dd><input type="text" id="gttTitle" /></dd>
                 <dt>Body:</dt>
-                <dd><textarea id="gttDesc" style="height:180px;width:300px"></textarea></dd>
+                <dd><textarea id="gttDesc" style="height: 180px; width: 300px;"></textarea></dd>
                 <dt>Attach:</dt>
                 <dd id="gttAttachments" />
                 <dt>Images:</dt>


### PR DESCRIPTION
- Fix member assignment buttons to persist across board changes
- Shift-click "Labels:" or "Members:" to clear
- Fix typos GMail -> Gmail