### PR TITLE
Remove garbage can from GtT icon by removing that class (Bq); make poppup location below icon instead of on top of it.

### DIFF
--- a/chrome/CHANGES.md
+++ b/chrome/CHANGES.md
@@ -4,6 +4,11 @@ A free tool that provides an extra 'Add card' button on Gmail UI to add current 
 
 CHANGE LOG:
 
+Version 2.7.2.28
+-----------------
+- Remove trash can from GtT pull down
+- Move popup location of GtT pull down to under icon
+
 Version 2.7.2.27
 -----------------
 - Use new version of Trello Client.js

--- a/chrome/style.css
+++ b/chrome/style.css
@@ -33,6 +33,7 @@
     border-bottom: 2px solid #ccc;
     background: #FEFEFE;
     padding: 0;
+    margin-top: 24px;
     opacity: 0.95;
     z-index: 9999;
     overflow: hidden;

--- a/chrome/views/popupView.js
+++ b/chrome/views/popupView.js
@@ -89,7 +89,7 @@ GmailToTrello.PopupView.prototype.confirmPopup = function() {
             this.html['add_to_trello'] =
                 '<div id="gttButton" class="T-I J-J5-Ji ar7 nf T-I-ax7 L3" ' // "lS T-I-ax7 ar7"
                   + 'data-tooltip="Add this Gmail to Trello">'
-                  + '<div aria-haspopup="true" role="button" class="J-J5-Ji W6eDmd L3 J-J5-Ji Bq L3" tabindex="0">' // class="J-J5-Ji W6eDmd L3 J-J5-Ji Bq L3">' //
+                  + '<div aria-haspopup="true" role="button" class="J-J5-Ji W6eDmd L3 J-J5-Ji L3" tabindex="0">' // class="J-J5-Ji W6eDmd L3 J-J5-Ji Bq L3">' // Bq = Delete icon
                   + img
                   + '<div id="gttDownArrow" class="G-asx T-I-J3 J-J5-Ji">&nbsp;</div></div></div>';
         }


### PR DESCRIPTION
Remove garbage can from GtT icon by removing that class (Bq); make poppup location below icon instead of on top of it.