### PR TITLE
Fixes for UI class name changes

### DIFF
--- a/chrome/CHANGES.md
+++ b/chrome/CHANGES.md
@@ -4,6 +4,11 @@ A free tool that provides an extra 'Add card' button on Gmail UI to add current 
 
 CHANGE LOG:
 
+Version 2.7.2.30
+-----------------
+- Gmail UI class names changed again, in gmailView we now use a single viewport: '.aia:first'. It was '.aeJ:first'. We no longer explicitly try to detect splitlayout, which may or may not work. Will need to test with folks.
+- Initial error message when retrieving attachment content fails with 0 length. Probably CORS/CORB new Chrome security model, need to retrieve data from background script. Fix in progress but will take a while to refactor uploading code.
+
 Version 2.7.2.29
 -----------------
 - Deeper highlighting for Labels and Assign, use gradient to indicate selected

--- a/chrome/app.js
+++ b/chrome/app.js
@@ -30,8 +30,8 @@ GmailToTrello.App.prototype.bindEvents = function() {
     });
     
     this.model.event.addListener('onAuthorized', function() {
-        gtt_log('onAuthorized');
-        gtt_log("Status: " + Trello.authorized().toString());
+        // gtt_log('onAuthorized');
+        // gtt_log("Status: " + Trello.authorized().toString());
         self.popupView.$popupContent.show();
         self.popupView.hideMessage();
     });
@@ -189,7 +189,7 @@ GmailToTrello.App.prototype.initialize = function() {
 
     this.model.isInitialized = false;
 
-    gtt_log('App:initialize');
+    // gtt_log('App:initialize');
     
     this.gmailView.detect();
 

--- a/chrome/content-script.js
+++ b/chrome/content-script.js
@@ -68,10 +68,10 @@ function gtt_log(data) {
  */
  function requestHandler(request, sender, sendResponse) {
     if (request && request.hasOwnProperty('message') && request.message === 'gtt:initialize') {
-        gtt_log('GlobalInit: '+globalInit.toString());
+        // gtt_log('GlobalInit: '+globalInit.toString());
         globalInit = true;
         // enough delay for gmail finishes rendering
-        gtt_log('tabs.onUpdated - complete');
+        // gtt_log('tabs.onUpdated - complete');
         jQuery(document).ready(function() {                    
             gtt_log('document.ready');
             getGmailObject();

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gmail-to-Trello",
   "short_name": "GtT",
-  "version": "2.7.2.29",
+  "version": "2.7.2.30",
   "manifest_version": 2,
   "description": "Gmail-to-Trello integration. Create new Trello cards from Google mail threads with backlinks.",
   "icons": {

--- a/chrome/views/gmailView.js
+++ b/chrome/views/gmailView.js
@@ -28,7 +28,7 @@ GmailToTrello.GmailView = function(parent) {
         emailAttachments: '.aZo', // Was: '.aQy',
         emailThreadID: '.a3s.aXjCH',
         emailIDs: ['data-thread-perm-id', 'data-thread-id', 'data-legacy-thread-id'],
-        viewport: '.aia:first', // Was: '.aeJ:first',
+        viewport: '.aia, .nH', // .aia = split view, .nH = breakout view // Was: '.aeJ:first', now using .first()
         // viewportSplit: '.aNW:first', // reading panel OBSOLETE (Ace, 2020-02-15): Don't know that this is ever used any more
         expandedEmails: '.h7',
         hiddenEmails: '.kv',
@@ -149,7 +149,7 @@ GmailToTrello.GmailView.prototype.parseData = function() {
         $viewport = $(this.selectors.viewportSplit, this.$root);
     } else {
 */
-        $viewport = $(this.selectors.viewport, this.$root);
+        $viewport = $(this.selectors.viewport, this.$root).first();
 //  }
     gtt_log('parseData::viewport: ' + JSON.stringify($viewport));
     if ($viewport.length == 0) {

--- a/chrome/views/gmailView.js
+++ b/chrome/views/gmailView.js
@@ -28,8 +28,8 @@ GmailToTrello.GmailView = function(parent) {
         emailAttachments: '.aZo', // Was: '.aQy',
         emailThreadID: '.a3s.aXjCH',
         emailIDs: ['data-thread-perm-id', 'data-thread-id', 'data-legacy-thread-id'],
-        viewport: '.aeJ:first',
-        viewportSplit: '.aNW:first', //reading panel
+        viewport: '.aia:first', // Was: '.aeJ:first',
+        // viewportSplit: '.aNW:first', // reading panel OBSOLETE (Ace, 2020-02-15): Don't know that this is ever used any more
         expandedEmails: '.h7',
         hiddenEmails: '.kv',
         emailInThreads: '.kv,.h7',
@@ -44,15 +44,17 @@ GmailToTrello.GmailView.prototype.preDetect = function() {
 
     var $activeGroup = $('.BltHke[role="main"]');
     
+/* // OBSOLETE (Ace, 2020-02-15): .find is always returning false, don't think detecting split needed any more
     if ($activeGroup.find('.apv, .apN').length > 0) { // .apv = old gmail, .apN = new gmail
         // gtt_log('detect: Detected SplitLayout');
 
         this.layoutMode = this.LAYOUT_SPLIT;
         this.$root = $activeGroup;
     } else {
+*/
         this.layoutMode = this.LAYOUT_DEFAULT;
         this.$root = $('body');
-    }
+//  }
 
     return this.detectToolbar();
 };
@@ -140,12 +142,15 @@ GmailToTrello.GmailView.prototype.parseData = function() {
     var self = this;
     var data = {};
 
+
+/* OBSOLETE (Ace, 2020-02-15): Don't think split is different than flat any more
     // find active email
     if (this.layoutMode === this.LAYOUT_SPLIT) {
         $viewport = $(this.selectors.viewportSplit, this.$root);
     } else {
+*/
         $viewport = $(this.selectors.viewport, this.$root);
-    }
+//  }
     gtt_log('parseData::viewport: ' + JSON.stringify($viewport));
     if ($viewport.length == 0) {
         return;

--- a/chrome/views/popupView.js
+++ b/chrome/views/popupView.js
@@ -44,7 +44,7 @@ GmailToTrello.PopupView = function(parent) {
 };
 
 GmailToTrello.PopupView.prototype.init = function() {
-    gtt_log('PopupView:init');
+    // gtt_log('PopupView:init');
     var self = this;
 
  //   if (!this.$toolBar) {
@@ -1165,7 +1165,7 @@ GmailToTrello.PopupView.prototype.validateData = function() {
     var images = mime_array('gttImages');
 
     var validateStatus = boardId && listId && title && description ? true : false; // Labels are not required
-    gtt_log('validateData: board:' + boardId + ' list:' + listId + ' title:' + title + ' desc:' + ((description || '') . length));
+    // gtt_log('validateData: board:' + boardId + ' list:' + listId + ' title:' + title + ' desc:' + ((description || '') . length));
 
     if (validateStatus) {
         newCard = {


### PR DESCRIPTION
Version 2.7.2.30
-----------------
- Gmail UI class names changed again, in gmailView we now use a single viewport: '.aia:first'. It was '.aeJ:first'. We no longer explicitly try to detect splitlayout, which may or may not work. Will need to test with folks.
- Initial error message when retrieving attachment content fails with 0 length. Probably CORS/CORB new Chrome security model, need to retrieve data from background script. Fix in progress but will take a while to refactor uploading code.